### PR TITLE
Read `outputDir` from `config` in case -o wasn't used

### DIFF
--- a/lib/lasso-cli.js
+++ b/lib/lasso-cli.js
@@ -357,7 +357,7 @@ function run(argv) {
                                     var targetHtml = fs.readFileSync(target, {encoding: 'utf8'});
                                     var injectOptions = {
                                         path: target,
-                                        outputDir: outputDir
+                                        outputDir: config.outputDir
                                     };
 
                                     targetHtml = injector.inject(targetHtml, lassoPageResult, injectOptions);
@@ -396,7 +396,7 @@ function run(argv) {
 
     if (args.watch) {
         var ignoreRules = watcherUtil.getIgnoreRules({
-                    outputDir: outputDir,
+                    outputDir: config.outputDir,
                     htmlDir: htmlDir,
                     injectInto: args.injectInto
                 });
@@ -421,3 +421,4 @@ function run(argv) {
 }
 
 module.exports = run;
+


### PR DESCRIPTION
I found this while trying to run [marko-widgets-client-rendering sample](https://github.com/marko-js-samples/marko-widgets-client-rendering).  If you don't use `--output-dir static/` as an argument to lasso-cli specified by the [`npm run build`](https://github.com/marko-js-samples/marko-widgets-client-rendering/blob/master/package.json#L7) command in that project, the `%STATIC_PATH%` placeholder won't get replaced with the default `./static`.  

This change ensures that you always use `config.outputDir` both in the `injector` and the `watcher` parts of lasso-cli.