### PR TITLE
Fixing Uncaught exception: TypeError: Object #<Object> has no method getHtmlBySlot()

### DIFF
--- a/lib/html-injector.js
+++ b/lib/html-injector.js
@@ -96,7 +96,7 @@ exports.inject = function(html, lassoPageResult, options) {
         }
     }
 
-    var slots = lassoPageResult.getHtmlBySlot();
+    var slots = lassoPageResult._htmlBySlot;
     for (var slotName in slots) {
         if (slots.hasOwnProperty(slotName)) {
             var slotHtml = slots[slotName];


### PR DESCRIPTION
## Fixing Uncaught exception: TypeError: Object #<Object> has no method getHtmlBySlot()

When this **lasso-cli** module is called from the
https://github.com/lasso-js-samples/lasso-cli (latest version 1.3
used), running _./run-dev.sh_ and _./run-prod.sh_ fails with the following
error.
``````````````

Uncaught exception: TypeError: Object #<Object> has no method
'getHtmlBySlot'
    at Object.exports.inject
(/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli
/lib/html-injector.js:99:33)
    at
/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli/
lib/lasso-cli.js:387:59
    at Array.forEach (native)
    at
/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli/
lib/lasso-cli.js:379:49
    at _fulfilled
(/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli
/node_modules/raptor-promises/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done
(/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli
/node_modules/raptor-promises/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch
(/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli
/node_modules/raptor-promises/node_modules/q/q.js:796:13)
    at
/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli/
node_modules/raptor-promises/node_modules/q/q.js:604:44
    at runSingle
(/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli
/node_modules/raptor-promises/node_modules/q/q.js:137:13)
    at flush
(/Users/dasathyakuma/respository/gitPvt/lasso-cli/node_modules/lasso-cli
/node_modules/raptor-promises/node_modules/q/q.js:125:13)
````````````

This is because **lassoPageResult** from **lassojs **core module returns an object that has **_htmlBySlot** as a key,
instead of **getHtmlBySlot()** and this is what is returned by
lib/slottracker.js. **Fixed it.**